### PR TITLE
Fix for Amazon Linux 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,7 +235,7 @@ else(MSVC)
 
   if(CMAKE_COMPILER_IS_GNUCC)
     # these flags are not known to clang
-    set(CMAKE_GCC_FLAGS "-Wl,--no-as-needed")
+    set(CMAKE_GCC_FLAGS "-Wl,--no-as-needed -lrt")
     set(CMAKE_RDYNAMIC_FLAG "-rdynamic")
   endif(CMAKE_COMPILER_IS_GNUCC)
 


### PR DESCRIPTION
### Description

This change fixes a problem with the marian-server compilation on Amazon Linux 2. 

Error log:

```
[100%] Linking CXX executable ../marian-server
/usr/local/cuda/lib64/libcudart_static.a(cudart_static.o): In function `__cudart866':
(.text+0x67a02): undefined reference to `shm_unlink'
(.text+0x67a1d): undefined reference to `shm_open'
(.text+0x67ab3): undefined reference to `shm_unlink'
/usr/local/cuda/lib64/libcudart_static.a(cudart_static.o): In function `__cudart627':
(.text+0x67c55): undefined reference to `shm_open'
/usr/local/cuda/lib64/libcudart_static.a(cudart_static.o): In function `__cudart751':
(.text+0x67de5): undefined reference to `shm_open'
/usr/local/cuda/lib64/libcudart_static.a(cudart_static.o): In function `__cudart642':
(.text+0x67f64): undefined reference to `shm_unlink'
collect2: error: ld returned 1 exit status
make[3]: *** [marian-server] Error 1
make[2]: *** [src/CMakeFiles/marian_server.dir/all] Error 2
make[1]: *** [src/CMakeFiles/marian_server.dir/rule] Error 2
make: *** [marian_server] Error 2
```
